### PR TITLE
fix ESM exports to support tree-shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
 
 ```
 {
-  <icon-set>: {
-    <icon-name>: <SVG String>
-  }
+  <icon-name>: <SVG String>
 }
 ```
 
@@ -26,13 +24,9 @@ for example:
 
 ```
 {
-  ea: {
-    camping: "<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">...</svg>"
-  }
+  camping: "<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">...</svg>"
 }
 ```
-
-TODO: Notes about Vue/Cedar
 
 ## Creating a custom sprite
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,47 @@
 
 ## Getting Started
 
-### Installation
+There are 2 primary ways of consuming Cedar Icons:
+- [reference the icon SVG via a sprite sheet](#Using-Icons-Inline)
+- [render the icon SVG content inline](#Creating-a-custom-sprite)
+
+Using a sprite sheet ensures that each icon used on your page is only included once. However this does create an additional maintenance cost as you must track exactly which icons are being used inside of your application, and adding a new icon to the page means generating a new sprite sheet.
+
+Using inline icon components is the easiest way to consume Cedar Icons, as it ensures that the icon content is always available where it needs to be. However it does mean that some icons might be included multiple times in your bundle, especially if you are doing server-side rendering.
+
+Which approach you take will depend on the needs of your project. Feel free to reach out to the Cedar team for help in assessing the best strategy for you.
+
+## Creating a custom sprite
+
+See the [CdrIcon](https://rei.github.io/rei-cedar-docs/components/icon/#svg-sprite) docs for more information on how to reference and load your sprite sheet in your application.
+
+### Via CLI
+
+`@rei/cedar-icons` provides a command-line interface for creating/editing a SVG symbol definition file.
+
+`npx icon-sprite` will start the CLI. Follow the instructions to create your customized sprite.
+
+NOTE: If you are editing an existing sprite via the CLI it will only look for icons currently in the repo and anything not found within will be excluded from the output file (this may change with a future feature update).
+
+### From within the repo
+
+`npm run sprite` will function the same as above.
+
+## Using Icons Inline
+
+To make it easier for consumers to inline individual icons we export single component versions of every SVG icon in this library from @rei/cedar. See the [CdrIcon docs](https://rei.github.io/rei-cedar-docs/components/icon/#inline-icon-components) for more information.
+
+## Programmatic Usage
 
 `npm install @rei/cedar-icons`
+
+### Distributed Files
+
+- `all-icons.svg`: SVG sprite sheet containing all of the icons.
+- `icons.esm.js`: ESM export of SVG markup. Exports are formatted in CamelCase and prefixed with `Icon`: `IconCaretDown`
+- `icons.js`: ESM export of SVG markup. Icon names are formatted in kebab-case: `caret-down`
+- `icons.json`: JSON object.  Icon names formatted in kebab-case: `caret-down`
+- `/icons/`: folder of .svg files. Filenames formatted in kebab-case: `caret-down.svg`
 
 ### Use
 
@@ -27,20 +65,6 @@ for example:
   camping: "<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">...</svg>"
 }
 ```
-
-## Creating a custom sprite
-
-### Via CLI
-
-`@rei/cedar-icons` provides a command-line interface for creating/editing a SVG symbol definition file.
-
-`npx icon-sprite` will start the CLI. Follow the instructions to create your customized sprite.
-
-NOTE: If you are editing an existing sprite via the CLI it will only look for icons currently in the repo and anything not found within will be excluded from the output file (this may change with a future feature update).
-
-### From within the repo
-
-`npm run sprite` will function the same as above.
 
 ## SVGs
 

--- a/build/icon-json.js
+++ b/build/icon-json.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const _ = require('lodash');
 
 const getSvg = svgFilePath => fs.readFileSync(svgFilePath, 'utf8');
 
@@ -12,7 +13,7 @@ const makeObj = (filePath, iconObj) => {
   for (let i = 0, l = files.length; i < l; i++) {
     const fileName = files[i];
     const newPath = path.join(filePath, fileName);
-    
+
     // check if it's a directory or file
     if (fs.statSync(newPath).isDirectory()) {
       iconObj[fileName] = {};
@@ -30,5 +31,9 @@ const iconObj = makeObj(path.resolve('icons/'), {});
 // TODO: remove json output?
 fs.outputFileSync('dist/icons.json', JSON.stringify(iconObj, ' ', 2));
 fs.outputFileSync('dist/icons.js', `module.exports = ${JSON.stringify(iconObj, ' ', 2)}`);
-fs.outputFileSync('dist/icons.esm.js', `export default ${JSON.stringify(iconObj, ' ', 2)}`);
 
+const esmFile = Object.keys(iconObj).map(iconName => {
+  return `export const ${_.upperFirst(_.camelCase(iconName))} = '${iconObj[iconName]}';`
+}).join('\n')
+
+fs.outputFileSync('dist/icons.esm.js', esmFile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar-icons",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar-icons",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://rei.github.io/cedar-icons/",
   "description": "REI Cedar Icon Library",
   "license": "MIT",


### PR DESCRIPTION
also updates docs to cover sprite vs. inline vs. programmatic usage