### PR TITLE
Update to sprite generation logic, correct readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To make it easier for consumers to inline individual icons we export single comp
 ### Distributed Files
 
 - `all-icons.svg`: SVG sprite sheet containing all of the icons.
-- `icons.esm.js`: ESM export of SVG markup. Exports are formatted in CamelCase and prefixed with `Icon`: `IconCaretDown`
+- `icons.esm.js`: ESM export of SVG markup. Exports are formatted in CamelCase: `CaretDown`
 - `icons.js`: ESM export of SVG markup. Icon names are formatted in kebab-case: `caret-down`
-- `icons.json`: JSON object.  Icon names formatted in kebab-case: `caret-down`
+- `icons.json`: JSON object. Icon names formatted in kebab-case: `caret-down`
 - `/icons/`: folder of .svg files. Filenames formatted in kebab-case: `caret-down.svg`
 
 ### Use

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To make it easier for consumers to inline individual icons we export single comp
 
 - `all-icons.svg`: SVG sprite sheet containing all of the icons.
 - `icons.esm.js`: ESM export of SVG markup. Exports are formatted in CamelCase: `CaretDown`
-- `icons.js`: ESM export of SVG markup. Icon names are formatted in kebab-case: `caret-down`
+- `icons.js`: CJS export of SVG markup. Icon names are formatted in kebab-case: `caret-down`
 - `icons.json`: JSON object. Icon names formatted in kebab-case: `caret-down`
 - `/icons/`: folder of .svg files. Filenames formatted in kebab-case: `caret-down.svg`
 

--- a/docs-src/views/Sprite.vue
+++ b/docs-src/views/Sprite.vue
@@ -63,7 +63,12 @@ export default {
   data() {
     return {
       formData: [],
-      sprites: svgstore(),
+      sprites: svgstore({
+        svgAttrs: {
+          xmlns: "http://www.w3.org/2000/svg",
+          style: "display: none;"
+        }
+      }),
     }
   },
   props: [
@@ -75,7 +80,7 @@ export default {
         this.sprites.add(icon, this.iconData[icon])
       });
 
-      download(this.sprites.toString(), 'sprite.svg', 'image/svg+xml');
+      download(this.sprites.toString({ inline: true }), 'sprite.svg', 'image/svg+xml');
     }
   }
 }


### PR DESCRIPTION
I noticed while looking at that social share component that the sprite created here had some extra markup you don't need when inlining. I cleaned that up and set `display: none` on it by default to make things easier for consumers too.

I noticed we said the esm export gets prepended with 'Icon' but that isn't true. If we meant to do that, I can make the update here to add that.