### PR TITLE
2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar-icons",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar-icons",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "homepage": "https://rei.github.io/cedar-icons/",
   "description": "REI Cedar Icon Library",
   "license": "MIT",


### PR DESCRIPTION
Pushing this up so the tag matches the published npm package (can't republish 2.6.0)